### PR TITLE
Update VEP95 AMI

### DIFF
--- a/config/prod/genie.yaml
+++ b/config/prod/genie.yaml
@@ -5,8 +5,8 @@ parameters:
   # VEP installation
   # Distibution: Amazon Linux.
   ComputeImageId: ami-033b8c0b4b16a03cd
-  DevComputeImageId: ami-065d339b204489584
+  # 95VEP: ami-0a0966a44218e21ab
+  DevComputeImageId: ami-0a0966a44218e21ab
 
-  # 95VEP: ami-065d339b204489584
   MainImage: sagebionetworks/genie:latest
   MutationImage: sagebionetworks/genie:vcf2maf


### PR DESCRIPTION
Added an index file that was missing. Both of these AMIs contain the VEP version 95 index files, just this one contains one more file needed for the infra to run