### PR TITLE
fast fail on lint_stack.sh script error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,10 @@ jobs:
     - stage: validate
       script:
         - yamllint ./config ./templates
-        - ./lint_stack.sh -l ./config/prod
+        - ./lint_stack.sh -l ./config/prod || travis_terminate 1
         - cfn-lint ./templates/**/*
     - stage: deploy
       script:
-        - ./lint_stack.sh -r
+        - ./lint_stack.sh -r || travis_terminate 1
         - travis_wait 30 sceptre launch prod --yes
 


### PR DESCRIPTION
The purpose is to make travis fail right after a script errors.  Without this travis may continue to run the rest of the build then fail at the end.